### PR TITLE
Add missing event flow

### DIFF
--- a/example/Admin.jsx
+++ b/example/Admin.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable functional/functional-parameters */
 /* eslint-disable functional/no-return-void */
 /* eslint-disable functional/no-expression-statement */
-import { setOptions } from '../src/events'
+import { buildConfig, setOptions } from '../src/events'
 
 export default (props) => {
 	console.log({ props })
@@ -9,6 +9,10 @@ export default (props) => {
 	setTimeout(() => {
 		setOptions([{ key: 'k', value: 1 }], props.currentPluginIndex)
 	}, 1000)
+
+	setTimeout(() => {
+		buildConfig()
+	}, 2000)
 
 	return <p>Example</p>
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
 		"@types/react-dom": "18.0.6",
 		"@typescript-eslint/eslint-plugin": "5.36.2",
 		"@typescript-eslint/parser": "5.36.2",
+		"@webcomponents/template-shadowroot": "^0.1.0",
 		"astro": "1.1.6",
 		"autoprefixer": "10.4.8",
 		"ava": "4.3.3",

--- a/planned-structure/src/pages/admin/[...page].astro
+++ b/planned-structure/src/pages/admin/[...page].astro
@@ -1,6 +1,5 @@
 ---
-import Admin from '../../../../layouts/Admin.astro'
-import { adminFactory, encode } from '../../../../src/'
+import { Admin, adminFactory, encode } from '../../../../src/'
 import example from '../../../../example/index.mjs'
 
 export const { getStaticPaths } = adminFactory({
@@ -24,3 +23,11 @@ console.log(Astro.props)
 <Admin {...Astro.props}>
 	<Content {...Astro.props} />
 </Admin>
+
+<script>
+	import { onSubmitConfig } from '../../../../src'
+
+	onSubmitConfig((data, onFinish) => {
+		console.log('onSubmitConfig', data, onFinish)
+	})
+</script>

--- a/src/events.ts
+++ b/src/events.ts
@@ -62,7 +62,7 @@ export const submitConfig = (data: string) => {
 const finish = (results: ClubsEventsDetailFinishConfiguration) => {
 	return document.body.dispatchEvent(
 		new CustomEvent<ClubsEventsDetailFinishConfiguration>(
-			ClubsEvents.SubmitConfiguration,
+			ClubsEvents.FinishConfiguration,
 			{
 				detail: results,
 				cancelable: true,

--- a/src/layouts/Admin.astro
+++ b/src/layouts/Admin.astro
@@ -45,7 +45,8 @@ const enabledPlugins = plugins
 				value={clubs.encodedClubsConfiguration}
 			/>
 			<script>
-				import { decode } from '../index'
+				import { decode, encode } from '../index'
+				import { submitConfig } from '../events'
 				import type {
 					ClubsConfiguration,
 					ClubsEventsUpdatePluginOptions,
@@ -109,6 +110,18 @@ const enabledPlugins = plugins
 						)
 					}
 				)
+
+				document.body.addEventListener(ClubsEvents.BuildConfiguration, (ev) => {
+					ev.preventDefault()
+
+					console.log('Received event', ClubsEvents.BuildConfiguration)
+
+					const encodedConfig = encode(currentConfig)
+
+					console.log('New configuration', encodedConfig)
+
+					submitConfig(encodedConfig)
+				})
 			</script>
 		</div>
 	</body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1695,6 +1695,11 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.37.tgz#8e6adc3f2759af52f0e85863dfb0b711ecc5c702"
   integrity sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw==
 
+"@webcomponents/template-shadowroot@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@webcomponents/template-shadowroot/-/template-shadowroot-0.1.0.tgz#adb3438d0d9a18e8fced08abc253f56b7eadab00"
+  integrity sha512-ry84Vft6xtRBbd4M/ptRodbOLodV5AD15TYhyRghCRgIcJJKmYmJ2v2BaaWxygENwh6Uq3zTfGPmlckKT/GXsQ==
+
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"


### PR DESCRIPTION
I've added missing event flows and now all data storing flows can be implemented.

Below is an overview of that flow:

1. **[Plugin]**: Any plugins can dispatch new plugin options or entire configs with `setOptions` (or `setConfig`)
Like the following sample code (yeah, why using setTimeout is that's just sample code)
https://github.com/dev-protocol/clubs-core/blob/437c0caa1d7141737eb7fe32f0747bb9e433044c/example/Admin.jsx#L6-L11
2. **[Core]**: The built-in Admin layout listens the event emission. This is handled by clubs-core and plugins can ignore it.
https://github.com/dev-protocol/clubs-core/blob/437c0caa1d7141737eb7fe32f0747bb9e433044c/src/layouts/Admin.astro#L65-L90
3. **[Core]**: When the built-in "**Save**" button under Admin.astro is clicked, the Save button dispatches the event.
The following example is dispatched it by the example plugin, but should be replaced by the Save button. Also, `buildConfig` function is not exported externally, so any plugins cannot call it.
https://github.com/dev-protocol/clubs-core/blob/437c0caa1d7141737eb7fe32f0747bb9e433044c/example/Admin.jsx#L14
4. **[Core]**: When Admin.astro detects that `buildConfig` has been called, Admin.astro encodes the in-memory ClubsConfiguration and dispatches the event.
https://github.com/dev-protocol/clubs-core/blob/437c0caa1d7141737eb7fe32f0747bb9e433044c/src/layouts/Admin.astro#L114-L124
5. **[Clubs website]**: Any websites build with Clubs can import `onSubmitConfig` from clubs-core and store new configuration values in their own way (although the following example does nothing).
https://github.com/dev-protocol/clubs-core/blob/437c0caa1d7141737eb7fe32f0747bb9e433044c/planned-structure/src/pages/admin/%5B...page%5D.astro#L27-L33