### PR TITLE
fix: currentPluginIndex value in props

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -47,21 +47,21 @@ const _staticPathsFromPlugins =
 		caller: 'getPagePaths' | 'getAdminPaths',
 		additionalProps?: (i: number) => Props
 	) =>
-		async (plugins: Plugins): Promise<ClubsStaticPaths> =>
-			(
-				await Promise.all(
-					plugins.map(async (plugin) => {
-						const results = await plugin[caller](plugin.options, config)
-						const updated = additionalProps
-							? results.map((res, i) => ({
+	async (plugins: Plugins): Promise<ClubsStaticPaths> =>
+		(
+			await Promise.all(
+				plugins.map(async (plugin) => {
+					const results = await plugin[caller](plugin.options, config)
+					const updated = additionalProps
+						? results.map((res, i) => ({
 								...res,
 								props: { ...res.props, ...additionalProps(plugin.pluginIndex) },
-							}))
-							: results
-						return updated
-					})
-				)
-			).flat()
+						  }))
+						: results
+					return updated
+				})
+			)
+		).flat()
 
 const _compose = (pluginResults: ClubsStaticPaths) =>
 	pluginResults.map((res) => ({
@@ -76,36 +76,36 @@ const _staticPagePathsFactory: (
 	pluginsMap: ClubsPluginsMap
 ) => () => Promise<ClubsGetStaticPathsResult> =
 	(configFetcher, pluginsMap) =>
-		// eslint-disable-next-line functional/functional-parameters
-		async (): Promise<ClubsGetStaticPathsResult> => {
-			const [config] = await getClubsConfig(configFetcher)
-			const plugins = await _listPlugins(config, pluginsMap)
-			const getResultsOfPlugins = _staticPathsFromPlugins(config, 'getPagePaths')
-			const pluginResults = await getResultsOfPlugins(plugins)
-			const staticPaths = _compose(pluginResults)
+	// eslint-disable-next-line functional/functional-parameters
+	async (): Promise<ClubsGetStaticPathsResult> => {
+		const [config] = await getClubsConfig(configFetcher)
+		const plugins = await _listPlugins(config, pluginsMap)
+		const getResultsOfPlugins = _staticPathsFromPlugins(config, 'getPagePaths')
+		const pluginResults = await getResultsOfPlugins(plugins)
+		const staticPaths = _compose(pluginResults)
 
-			return staticPaths
-		}
+		return staticPaths
+	}
 
 const _staticAdminPathsFactory: (
 	configFetcher: ClubsFunctionConfigFetcher,
 	pluginsMap: ClubsPluginsMap
 ) => () => Promise<ClubsGetStaticPathsResult> =
 	(configFetcher, pluginsMap) =>
-		// eslint-disable-next-line functional/functional-parameters
-		async (): Promise<ClubsGetStaticPathsResult> => {
-			const [config, encodedClubsConfiguration] = await getClubsConfig(
-				configFetcher
-			)
-			const pluginMetas = Object.keys(pluginsMap).map((name) => ({
-				name,
-				meta: pluginsMap[name].meta,
-			}))
-			const plugins = await _listPlugins(config, pluginsMap)
-			const getResultsOfPlugins = _staticPathsFromPlugins(
-				config,
-				'getAdminPaths',
-				(currentPluginIndex) =>
+	// eslint-disable-next-line functional/functional-parameters
+	async (): Promise<ClubsGetStaticPathsResult> => {
+		const [config, encodedClubsConfiguration] = await getClubsConfig(
+			configFetcher
+		)
+		const pluginMetas = Object.keys(pluginsMap).map((name) => ({
+			name,
+			meta: pluginsMap[name].meta,
+		}))
+		const plugins = await _listPlugins(config, pluginsMap)
+		const getResultsOfPlugins = _staticPathsFromPlugins(
+			config,
+			'getAdminPaths',
+			(currentPluginIndex) =>
 				({
 					clubs: {
 						encodedClubsConfiguration,
@@ -113,12 +113,12 @@ const _staticAdminPathsFactory: (
 						plugins: pluginMetas,
 					},
 				} as ClubsPropsAdminPages)
-			)
-			const pluginResults = await getResultsOfPlugins(plugins)
-			const staticPaths = _compose(pluginResults)
+		)
+		const pluginResults = await getResultsOfPlugins(plugins)
+		const staticPaths = _compose(pluginResults)
 
-			return staticPaths
-		}
+		return staticPaths
+	}
 
 export const pageFactory: ClubsFunctionPageFactory = (options) => {
 	const getStaticPaths = _staticPagePathsFactory(

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,12 @@ export type ClubsPlugin = Readonly<{
 	readonly options: ClubsPluginOptions
 }>
 
+export type ClubsPluginDetails = ClubsPlugin &
+	ClubsFunctionPlugin &
+	Readonly<{
+		readonly pluginIndex: number
+	}>
+
 export type ClubsConfiguration = Readonly<{
 	readonly name: string
 	readonly twitterHandle: string


### PR DESCRIPTION
Fixed the assignment of wrong index values in the clubs props for our astro components. The assignment was done after doing filtering of plugins at various stages based on activation, development stage, etc. This was causing the assigment of 0 or wrong index value to currentPluginIndex.