### PR TITLE
test: plugin set options

### DIFF
--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -1,0 +1,177 @@
+import test from 'ava'
+
+import { encode } from './encode'
+import { adminFactory } from './factory'
+import {
+	ClubsConfiguration,
+	ClubsEventsDetailUpdatePluginOptions,
+	ClubsPluginOption,
+} from './types'
+import { updatePluginOptionsEventListener } from './fixtures/utils'
+
+const singleOptionPluginConfig: ClubsConfiguration = {
+	name: '',
+	twitterHandle: '',
+	description: '',
+	url: '',
+	propertyAddress: '',
+	adminRolePoints: 0,
+	plugins: [
+		{
+			name: 'home',
+			options: [],
+			enable: true,
+		},
+		{
+			name: 'buy',
+			options: [],
+			enable: true,
+		},
+		{
+			name: 'nft',
+			options: [],
+			enable: false,
+		},
+		{
+			name: 'community',
+			options: [{ key: 'guild', value: 'https://www.testguild.com' }],
+			enable: true,
+		},
+		{
+			name: 'contact',
+			options: [{ key: 'requiredDev', value: 100 }],
+			enable: true,
+		},
+		{
+			name: 'membership',
+			options: [{ key: 'count', value: 10 }],
+			enable: true,
+		},
+	],
+}
+
+const pluginsMap = {
+	home: {
+		getPagePaths: async (
+			_: any,
+			{
+				name,
+				propertyAddress,
+			}: { readonly name: string; readonly propertyAddress: string }
+		) => [
+				{ paths: ['home'], component: null, props: { name, propertyAddress } },
+			],
+		getAdminPaths: async (options: readonly ClubsPluginOption[]) => [
+			{
+				paths: ['home'],
+				component: null,
+				props: { options },
+			},
+		],
+		meta: { displayName: 'Home' },
+	},
+	buy: {
+		getPagePaths: async (
+			_: any,
+			{
+				name,
+				propertyAddress,
+			}: { readonly name: string; readonly propertyAddress: string }
+		) => [
+				{ paths: ['buy'], component: null, props: { name, propertyAddress } },
+			],
+		getAdminPaths: async (options: readonly ClubsPluginOption[]) => [
+			{
+				paths: ['buy'],
+				component: null,
+				props: { options },
+			},
+		],
+		meta: { displayName: 'Buy' },
+	},
+	community: {
+		getPagePaths: async (
+			_: any,
+			{
+				name,
+				propertyAddress,
+			}: { readonly name: string; readonly propertyAddress: string }
+		) => [
+				{
+					paths: ['community'],
+					component: null,
+					props: { name, propertyAddress },
+				},
+			],
+		getAdminPaths: async (options: readonly ClubsPluginOption[]) => [
+			{
+				paths: ['community'],
+				component: null,
+				props: { options },
+			},
+		],
+		meta: { displayName: 'Community' },
+	},
+	nft: {
+		getPagePaths: async (
+			_: any,
+			{
+				name,
+				propertyAddress,
+			}: { readonly name: string; readonly propertyAddress: string }
+		) => [
+				{ paths: ['nft'], component: null, props: { name, propertyAddress } },
+			],
+		getAdminPaths: async (options: readonly ClubsPluginOption[]) => [
+			{
+				paths: ['nft'],
+				component: null,
+				props: { options },
+			},
+		],
+		meta: { displayName: 'NFT' },
+	},
+}
+
+test('should update the config correctly', async (t) => {
+	// Make sure that old config is up to date as per test.
+	const communityPluginGuildOption =
+		singleOptionPluginConfig.plugins[3].options[0]
+	t.is(communityPluginGuildOption.value, 'https://www.testguild.com')
+
+	// Encode the configuration.
+	const encodedConfig = encode(singleOptionPluginConfig)
+	// Get the static path info.
+	const { getStaticPaths } = adminFactory({
+		config: () => encodedConfig,
+		plugins: {
+			...pluginsMap,
+		},
+	})
+	// Fetch the path details.
+	const pathDetails: any = (await getStaticPaths()).find(
+		(i: any) => i.params.page === 'community'
+	)
+
+	// Assert that pluginIndex is equal to that in the config.
+	t.is(pathDetails.props.clubs.currentPluginIndex, 3)
+
+	// Create a new artificial update.
+	const updateDetails: ClubsEventsDetailUpdatePluginOptions = {
+		data: [{ key: 'guild', value: 'https://www.newTestGuild.com' }],
+		pluginIndex: pathDetails.props.clubs.currentPluginIndex || 0,
+	}
+
+	// Call the event listener that performs updates and returns the new config.
+	const newConfig = await updatePluginOptionsEventListener(
+		updateDetails,
+		singleOptionPluginConfig
+	)
+
+	// The new config should not match the old config.
+	t.notDeepEqual(singleOptionPluginConfig, newConfig)
+
+	// The new config update should be reflected here.
+	const newCommunityPluginGuildOption = newConfig.plugins[3].options[0]
+	t.is(newCommunityPluginGuildOption.value, 'https://www.newTestGuild.com')
+})

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -59,8 +59,8 @@ const pluginsMap = {
 				propertyAddress,
 			}: { readonly name: string; readonly propertyAddress: string }
 		) => [
-				{ paths: ['home'], component: null, props: { name, propertyAddress } },
-			],
+			{ paths: ['home'], component: null, props: { name, propertyAddress } },
+		],
 		getAdminPaths: async (options: readonly ClubsPluginOption[]) => [
 			{
 				paths: ['home'],
@@ -78,8 +78,8 @@ const pluginsMap = {
 				propertyAddress,
 			}: { readonly name: string; readonly propertyAddress: string }
 		) => [
-				{ paths: ['buy'], component: null, props: { name, propertyAddress } },
-			],
+			{ paths: ['buy'], component: null, props: { name, propertyAddress } },
+		],
 		getAdminPaths: async (options: readonly ClubsPluginOption[]) => [
 			{
 				paths: ['buy'],
@@ -97,12 +97,12 @@ const pluginsMap = {
 				propertyAddress,
 			}: { readonly name: string; readonly propertyAddress: string }
 		) => [
-				{
-					paths: ['community'],
-					component: null,
-					props: { name, propertyAddress },
-				},
-			],
+			{
+				paths: ['community'],
+				component: null,
+				props: { name, propertyAddress },
+			},
+		],
 		getAdminPaths: async (options: readonly ClubsPluginOption[]) => [
 			{
 				paths: ['community'],
@@ -120,8 +120,8 @@ const pluginsMap = {
 				propertyAddress,
 			}: { readonly name: string; readonly propertyAddress: string }
 		) => [
-				{ paths: ['nft'], component: null, props: { name, propertyAddress } },
-			],
+			{ paths: ['nft'], component: null, props: { name, propertyAddress } },
+		],
 		getAdminPaths: async (options: readonly ClubsPluginOption[]) => [
 			{
 				paths: ['nft'],

--- a/src/fixtures/utils.ts
+++ b/src/fixtures/utils.ts
@@ -1,0 +1,16 @@
+import { ClubsConfiguration, ClubsPlugin, ClubsPluginOptions } from '../types'
+
+export const updatePluginOptionsEventListener = async (
+	detail: { readonly data: ClubsPluginOptions; readonly pluginIndex: number },
+	currentConfig: ClubsConfiguration
+): Promise<ClubsConfiguration> => {
+	const { data, pluginIndex } = detail
+
+	const updatedPlugins = [...currentConfig.plugins].map(
+		(mplg: ClubsPlugin, i) =>
+			i === pluginIndex ? { ...mplg, options: data } : mplg
+	)
+	const updatedConfig = { ...currentConfig, plugins: updatedPlugins }
+
+	return updatedConfig
+}

--- a/src/layouts/Admin.astro
+++ b/src/layouts/Admin.astro
@@ -50,6 +50,7 @@ const enabledPlugins = plugins
 					ClubsEventsUpdateConfiguration,
 				} from '../types'
 				import { ClubsEvents } from '../types'
+				import { updatePluginOptionsEventListener } from '../fixtures/utils'
 
 				let currentConfig: ClubsConfiguration = decode(
 					(
@@ -61,7 +62,7 @@ const enabledPlugins = plugins
 
 				document.body.addEventListener(
 					ClubsEvents.UpdatePluginOptions,
-					(ev) => {
+					async (ev) => {
 						ev.preventDefault()
 						const {
 							detail: { data, pluginIndex },
@@ -72,10 +73,11 @@ const enabledPlugins = plugins
 							pluginIndex,
 						})
 
-						const updatedPlugins = [...currentConfig.plugins].map((mplg, i) =>
-							i === pluginIndex ? { ...mplg, options: data } : mplg
+						const updatedConfig = await updatePluginOptionsEventListener(
+							{ data, pluginIndex },
+							currentConfig
 						)
-						const updatedConfig = { ...currentConfig, plugins: updatedPlugins }
+
 						currentConfig = updatedConfig
 
 						console.log(


### PR DESCRIPTION
Add a util helper function for update plugin options, that takes in current config along with update details and returns a new config with the modifications. A uni test has also been added to test the same, where we check that plugin index in the astro props is the same as plugin index in the config and the updates are made in the current plugin options.