### PR TITLE
Add many properties for clubs.plugins

### DIFF
--- a/src/layouts/Admin.astro
+++ b/src/layouts/Admin.astro
@@ -8,9 +8,9 @@ import '../styles/global.scss'
 const { clubs } = Astro.props as ClubsPropsAdminPages
 
 const config = decode(clubs.encodedClubsConfiguration)
-const { name, plugins } = config
+const { name } = config
 
-const enabledPlugins = plugins
+const enabledPlugins = clubs.plugins
 	.filter((plugin) => plugin.enable === true)
 	.filter((plugin) => plugin.name.toUpperCase() !== 'ADMIN')
 ---

--- a/src/layouts/AdminSidebar.astro
+++ b/src/layouts/AdminSidebar.astro
@@ -1,5 +1,15 @@
 ---
-const { name, enabledPlugins } = Astro.props
+import { ClubsPropsClubsPlugin } from '../types'
+
+const { name, enabledPlugins } = Astro.props as {
+	name: string
+	enabledPlugins: ClubsPropsClubsPlugin[]
+}
+
+const cache = new Set<string>()
+const onlyFirstItems = enabledPlugins.filter(({ name }) =>
+	cache.has(name) ? false : cache.add(name)
+)
 ---
 
 <h1 class="font-title text-lg font-bold mb-16">{name}</h1>
@@ -8,9 +18,9 @@ const { name, enabledPlugins } = Astro.props
 	<a class="mb-16 text-sm" href="/admin/plugins">Plugins</a>
 
 	{
-		enabledPlugins.map((plugin: any) => (
-			<a class="mb-4 text-sm capitalize" href={plugin.name}>
-				{plugin.name}
+		onlyFirstItems.map((plugin) => (
+			<a class="mb-4 text-sm capitalize" href={plugin.pathname}>
+				{plugin.meta.displayName}
 			</a>
 		))
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,15 +115,20 @@ export type ClubsFunctionClubsConfigurationSetter = <
 	nextConfiguration: T
 ) => T
 
+export type ClubsPropsClubsPlugin = Omit<
+	ClubsPluginDetails,
+	'getPagePaths' | 'getAdminPaths'
+> & {
+	readonly paths: ClubsStaticPaths
+	readonly page: string
+	readonly pathname: string
+}
+
 export type ClubsPropsAdminPages = Props & {
 	readonly clubs: {
 		readonly currentPluginIndex: number
 		readonly encodedClubsConfiguration: string
-		readonly plugins: ReadonlyArray<
-			Omit<ClubsPluginDetails, 'getPagePaths' | 'getAdminPaths'> & {
-				readonly paths: ClubsStaticPaths
-			}
-		>
+		readonly plugins: ReadonlyArray<ClubsPropsClubsPlugin>
 	}
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,13 +44,14 @@ export type ClubsConfiguration = Readonly<{
 	readonly plugins: readonly ClubsPlugin[]
 }>
 
-export type ClubsStaticPath = Readonly<{
+export type ClubsStaticPath<P = Props | undefined> = Readonly<{
 	readonly paths: readonly (undefined | string)[]
 	readonly component: unknown
-	readonly props?: Props
+	readonly props: P
 }>
 
-export type ClubsStaticPaths = readonly ClubsStaticPath[]
+export type ClubsStaticPaths<P = Props | undefined> =
+	readonly ClubsStaticPath<P>[]
 
 export type ClubsFunctionGetPagePaths = (
 	options: readonly ClubsPluginOption[],
@@ -118,10 +119,11 @@ export type ClubsPropsAdminPages = Props & {
 	readonly clubs: {
 		readonly currentPluginIndex: number
 		readonly encodedClubsConfiguration: string
-		readonly plugins: ReadonlyArray<{
-			readonly name: string
-			readonly meta: ClubsPluginMeta
-		}>
+		readonly plugins: ReadonlyArray<
+			Omit<ClubsPluginDetails, 'getPagePaths' | 'getAdminPaths'> & {
+				readonly paths: ClubsStaticPaths
+			}
+		>
 	}
 }
 


### PR DESCRIPTION
With this PR, Astro.props.clubs.plugins for Admin will have the following properties:
- paths
- pathname
- page
- name
- enable
- options
- meta
- pluginIndex