### PR TITLE
fix(integration): show connection btn in all admin layouts

### DIFF
--- a/src/layouts/Admin.astro
+++ b/src/layouts/Admin.astro
@@ -91,7 +91,7 @@ const SlotsAsideAfterBuiltInButtons =
 				</div>
 			</main>
 			<div class="container mx-auto px-2 lg:px-0 py-8 lg:py-16">
-				<Aside config={config}>
+				<Aside config={config} showConnectButton={true}>
 					{
 						SlotsAsideAfterBuiltInButtons ? (
 							<SlotsAsideAfterBuiltInButtons {...Astro.props} />


### PR DESCRIPTION
This changes enables all layout inheriting from Admin.astro to show connection button.