### PR TITLE
Type inference improvements

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -10,7 +10,7 @@ import {
 	ClubsFunctionGetApiPaths,
 } from '../src'
 
-export const getPagePaths: ClubsFunctionGetPagePaths = async () => [
+export const getPagePaths = (async () => [
 	{ paths: [], component: Example },
 	{
 		paths: ['example'],
@@ -21,17 +21,17 @@ export const getPagePaths: ClubsFunctionGetPagePaths = async () => [
 			someMethod: (i: unknown) => i,
 		},
 	},
-]
+]) satisfies ClubsFunctionGetPagePaths
 
-export const getAdminPaths: ClubsFunctionGetAdminPaths = async (options) => [
+export const getAdminPaths = (async (options) => [
 	{
 		paths: ['example'],
 		component: Admin,
 		props: { options },
 	},
-]
+]) satisfies ClubsFunctionGetAdminPaths
 
-export const getSlots: ClubsFunctionGetSlots = async (options) => [
+export const getSlots = (async (options) => [
 	{
 		slot: ClubsSlotName.AdminModalCcontent,
 		component: Modal,
@@ -43,9 +43,9 @@ export const getSlots: ClubsFunctionGetSlots = async (options) => [
 		component: Modal,
 		props: { x: 123 },
 	},
-]
+]) satisfies ClubsFunctionGetSlots
 
-export const getApiPaths: ClubsFunctionGetApiPaths = async (options) => [
+export const getApiPaths = (async (options) => [
 	{
 		paths: [],
 		method: 'GET',
@@ -53,7 +53,7 @@ export const getApiPaths: ClubsFunctionGetApiPaths = async (options) => [
 			body: JSON.stringify({ options, body: request.body }),
 		}),
 	},
-]
+]) satisfies ClubsFunctionGetApiPaths
 
 export const meta = {
 	id: 'example',

--- a/example/theme.ts
+++ b/example/theme.ts
@@ -10,21 +10,20 @@ import {
 	ClubsSlotName,
 } from '../src'
 
-export const getPagePaths: ClubsFunctionGetPagePaths = async () => []
+export const getPagePaths = (async () => [
+	{ paths: ['theme'], component: Admin, props: { a: 1 } },
+]) satisfies ClubsFunctionGetPagePaths
 
-export const getAdminPaths: ClubsFunctionGetAdminPaths = async () => [
-	{ paths: ['theme'], component: Admin },
-]
+export const getAdminPaths = (async () => [
+	{ paths: ['theme'], component: Admin, props: { a: 1 } },
+]) satisfies ClubsFunctionGetAdminPaths
 
-export const getLayout: ClubsFunctionGetLayout = async () => ({
+export const getLayout = (async () => ({
 	layout: Layout,
-})
+	props: { a: 1 },
+})) satisfies ClubsFunctionGetLayout
 
-export const getSlots: ClubsFunctionGetSlots = async (
-	options,
-	_,
-	{ paths }
-) => {
+export const getSlots = (async (options, _, { paths }) => {
 	return [
 		{
 			slot: ClubsSlotName.AdminModalCcontent,
@@ -32,7 +31,7 @@ export const getSlots: ClubsFunctionGetSlots = async (
 			props: { x: 456 },
 		},
 	]
-}
+}) satisfies ClubsFunctionGetSlots
 
 export const meta = {
 	id: 'theme',

--- a/example/theme.ts
+++ b/example/theme.ts
@@ -20,7 +20,7 @@ export const getAdminPaths = (async () => [
 
 export const getLayout = (async () => ({
 	layout: Layout,
-	props: { a: 1 },
+	props: { tProps: 1 },
 })) satisfies ClubsFunctionGetLayout
 
 export const getSlots = (async (options, _, { paths }) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-core",
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"description": "Core library for Clubs",
 	"main": "dist/index.mjs",
 	"exports": {

--- a/planned-structure/src/pages/[...page].astro
+++ b/planned-structure/src/pages/[...page].astro
@@ -1,10 +1,15 @@
 ---
-import { pageFactory, encode, ClubsFunctionPageFactory } from '../../../src/'
+import {
+	pageFactory,
+	encode,
+	type ClubsFunctionPageFactoryResult,
+	type ClubsFunctionFactoryOptions,
+} from '../../../src/'
 import example from '../../../example/index'
 import theme from '../../../example/theme'
 import type { InferGetStaticPropsType } from 'astro'
 
-export const { getStaticPaths } = pageFactory({
+const options = {
 	config: () =>
 		encode({
 			name: 'Debug',
@@ -22,7 +27,11 @@ export const { getStaticPaths } = pageFactory({
 			],
 		}),
 	plugins: [theme, example],
-}) satisfies ReturnType<ClubsFunctionPageFactory>
+} satisfies ClubsFunctionFactoryOptions
+
+export const { getStaticPaths } = pageFactory(
+	options
+) as ClubsFunctionPageFactoryResult<typeof options>
 
 type Props = InferGetStaticPropsType<typeof getStaticPaths>
 

--- a/planned-structure/src/pages/[...page].astro
+++ b/planned-structure/src/pages/[...page].astro
@@ -1,7 +1,8 @@
 ---
-import { pageFactory, encode } from '../../../src/'
+import { pageFactory, encode, ClubsFunctionPageFactory } from '../../../src/'
 import example from '../../../example/index'
 import theme from '../../../example/theme'
+import type { InferGetStaticPropsType } from 'astro'
 
 export const { getStaticPaths } = pageFactory({
 	config: () =>
@@ -21,7 +22,9 @@ export const { getStaticPaths } = pageFactory({
 			],
 		}),
 	plugins: [theme, example],
-})
+}) satisfies ReturnType<ClubsFunctionPageFactory>
+
+type Props = InferGetStaticPropsType<typeof getStaticPaths>
 
 const Layout = Astro.props.layout
 const Content = Astro.props.component

--- a/src/events.test.ts
+++ b/src/events.test.ts
@@ -58,7 +58,9 @@ const pluginsMap = [
 	{
 		getPagePaths: async () => [],
 		getAdminPaths: async () => [],
-		getLayout: async () => null as unknown as AstroComponentFactory,
+		getLayout: async () => ({
+			layout: null as unknown as AstroComponentFactory,
+		}),
 		meta: {
 			id: 'theme',
 			displayName: 'Home',

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -20,10 +20,12 @@ import type {
 	ClubsFunctionGetPagePaths,
 	ClubsFunctionGetAdminPaths,
 	ClubsFunctionApiFactory,
+	ClubsGetStaticPathsAdminResult,
 } from './types'
 import { ClubsPluginCategory } from './types'
 import { getClubsConfig } from './getClubsConfig'
 import type { APIRoute, Props } from 'astro'
+import { AstroComponentFactory } from 'astro/dist/runtime/server'
 
 type Plugins<P extends ClubsFunctionPlugin = ClubsFunctionPlugin> =
 	readonly ClubsPluginDetails<P>[]
@@ -169,8 +171,11 @@ const _slotsFromPlugins =
 const _pathsToPage = (paths: readonly (string | undefined)[]) =>
 	paths.join('/') || undefined
 
-const _compose = <P extends Props>(
-	pluginResults: readonly ClubsStaticPathWithDetails[]
+const _compose = <
+	P extends Props,
+	A extends ClubsStaticPathWithDetails = ClubsStaticPathWithDetails
+>(
+	pluginResults: readonly A[]
 ) =>
 	pluginResults.map((res) => ({
 		params: {
@@ -217,7 +222,7 @@ const _staticPagePathsFactory: (
 		)
 		const staticPaths = _compose<ClubsPropsPages>(
 			slotsInjected
-		) as ClubsGetStaticPathsResult<ClubsPropsPages>
+		) as ClubsGetStaticPathsResult
 
 		return staticPaths
 	}
@@ -225,10 +230,10 @@ const _staticPagePathsFactory: (
 const _staticAdminPathsFactory: (
 	configFetcher: ClubsFunctionConfigFetcher,
 	pluginsMap: ClubsPlugins
-) => () => Promise<ClubsGetStaticPathsResult<ClubsPropsAdminPages>> =
+) => () => Promise<ClubsGetStaticPathsAdminResult> =
 	(configFetcher, pluginsMap) =>
 	// eslint-disable-next-line functional/functional-parameters
-	async (): Promise<ClubsGetStaticPathsResult<ClubsPropsAdminPages>> => {
+	async (): Promise<ClubsGetStaticPathsAdminResult> => {
 		const [config, encodedClubsConfiguration] = await getClubsConfig(
 			configFetcher
 		)
@@ -287,9 +292,7 @@ const _staticAdminPathsFactory: (
 			}))
 		)
 
-		const staticPaths = _compose<ClubsPropsAdminPages>(
-			slotsInjected
-		) as ClubsGetStaticPathsResult<ClubsPropsAdminPages>
+		const staticPaths = _compose<ClubsPropsAdminPages>(slotsInjected)
 
 		return staticPaths
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,7 +280,7 @@ export type ClubsThemePluginMeta = ClubsPluginMeta & {
 }
 
 export type ClubsFunctionFactoryResult<T> = {
-	readonly getStaticPaths: (opts: GetStaticPathsOptions) => Promise<T>
+	readonly getStaticPaths: (opts?: GetStaticPathsOptions) => Promise<T>
 	readonly getCurrentConfig: () => Promise<ClubsConfiguration>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -332,7 +332,15 @@ export type ClubsInferFactoryPropsType<
 				? U extends
 						| Array<{ props?: infer V }>
 						| ReadonlyArray<{ props?: infer V }>
-					? V
+					? P['getSlots'] extends
+							| ((...args: any) => Promise<infer S>)
+							| undefined
+						? S extends
+								| Array<{ props?: infer C }>
+								| ReadonlyArray<{ props?: infer C }>
+							? V & C
+							: Props
+						: Props
 					: Props
 				: Props
 			: Props

--- a/src/types.ts
+++ b/src/types.ts
@@ -332,15 +332,7 @@ export type ClubsInferFactoryPropsType<
 				? U extends
 						| Array<{ props?: infer V }>
 						| ReadonlyArray<{ props?: infer V }>
-					? P['getSlots'] extends
-							| ((...args: any) => Promise<infer S>)
-							| undefined
-						? S extends
-								| Array<{ props?: infer C }>
-								| ReadonlyArray<{ props?: infer C }>
-							? V & C
-							: Props
-						: Props
+					? V
 					: Props
 				: Props
 			: Props

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,7 +141,7 @@ export type ClubsFunctionGetLayout<P extends Props = Props> = (
 	config: ClubsConfiguration,
 	utils: ClubsFactoryUtils
 ) => Promise<
-	ClubsBaseStaticPath<P> & {
+	Omit<ClubsBaseStaticPath<P>, 'layout'> & {
 		readonly layout: AstroComponentFactory
 	}
 >
@@ -293,7 +293,15 @@ export type ClubsFunctionPageFactoryResult<
 		ClubsInferFactoryPropsType<
 			O extends { plugins: infer P } ? P : never,
 			'getPagePaths'
-		> & { readonly signals?: readonly (ClubsPluginSignal | string)[] }
+		> &
+			ClubsInferFactoryPropsType<
+				O extends { plugins: infer P } ? P : never,
+				'getLayout'
+			> & { readonly signals?: readonly (ClubsPluginSignal | string)[] },
+		ClubsInferFactoryPropsType<
+			O extends { plugins: infer P } ? P : never,
+			'getSlots'
+		>
 	>
 >
 
@@ -304,7 +312,11 @@ export type ClubsFunctionAdminFactoryResult<
 		ClubsInferFactoryPropsType<
 			O extends { plugins: infer P } ? P : never,
 			'getAdminPaths'
-		>
+		> &
+			ClubsInferFactoryPropsType<
+				O extends { plugins: infer P } ? P : never,
+				'getLayout'
+			>
 	>
 >
 
@@ -321,17 +333,20 @@ export type ClubsFunctionOnSubmitConfiguration = (
 
 export type ClubsInferFactoryPropsType<
 	T extends ClubsPlugins,
-	F extends keyof ClubsFunctionPlugin
+	F extends keyof Omit<ClubsFunctionPlugin, 'getApiPaths' | 'meta'>
 > = T extends Array<infer P> | ReadonlyArray<infer P>
 	? P extends ClubsFunctionPlugin
 		? P[F] extends
 				| ClubsFunctionGetPagePaths
 				| ClubsFunctionGetAdminPaths
+				| ClubsFunctionGetSlots
+				| ClubsFunctionGetLayout
 				| undefined
 			? P[F] extends ((...args: any) => Promise<infer U>) | undefined
 				? U extends
 						| Array<{ props?: infer V }>
 						| ReadonlyArray<{ props?: infer V }>
+						| { props?: infer V }
 					? V
 					: Props
 				: Props
@@ -354,6 +369,7 @@ export type ClubsFunctionApiFactory = (
 export type ClubsFunctionStandardPlugin = Readonly<{
 	readonly getPagePaths?: ClubsFunctionGetPagePaths
 	readonly getAdminPaths?: ClubsFunctionGetAdminPaths
+	readonly getLayout?: ClubsFunctionGetLayout
 	readonly getSlots?: ClubsFunctionGetSlots
 	readonly getApiPaths?: ClubsFunctionGetApiPaths
 	readonly meta: ClubsPluginMeta


### PR DESCRIPTION
Improved type inference for `pageFactory` and `adminFactory` to correctly handle the values ​​they are actually returning.

<img width="938" alt="Screenshot 2023-10-19 171057" src="https://github.com/dev-protocol/clubs-core/assets/1970283/61467ec2-af8c-453d-81cb-373b8a97613c">

These are not breaking changes, but the following changes are required for correct type inference:
### For `getPagePaths`, `getPagePaths` and `getSlots`
```ts
export const getPagePaths: ClubsFunctionGetPagePaths = async () => [
	{ paths: [], component: Example },
]
```
▼
```ts
export const getPagePaths = (async () => [
	{ paths: [], component: Example },
]) satisfies ClubsFunctionGetPagePaths
```

### For each `[...page].astro`
```ts
export const { getStaticPaths } = pageFactory(
	options
)
```
▼
```ts
const options = {
	config: () => `…`,
	plugins: [theme, example],
} satisfies ClubsFunctionFactoryOptions

export const { getStaticPaths } = pageFactory(
	options
) as ClubsFunctionPageFactoryResult<typeof options>

type Props = InferGetStaticPropsType<typeof getStaticPaths>
```


