### PR TITLE
Temporarily use `attribute` as dark mode strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-core",
-	"version": "2.4.0",
+	"version": "2.4.1-alpha.0",
 	"description": "Core library for Clubs",
 	"main": "dist/index.mjs",
 	"exports": {

--- a/src/styles/clubs.theme.scss
+++ b/src/styles/clubs.theme.scss
@@ -9,7 +9,7 @@ $theme: (
 	surface-dark: 'dp-blue-grey',
 	background: 'dp-white.200',
 	dark-background: 'dp-blue-grey.600',
-	dark-mode: 'media',
+	dark-mode: 'attribute',
 	extend: (
 		padding: (
 			xs: 0.3rem,


### PR DESCRIPTION
To keep the difference between the main and release branches of Clubs as small as possible until [this overhaul](https://www.pivotaltracker.com/story/show/186541549) is complete, I activate an explicit dark mode with attributes.
