### PR TITLE
Fix: Checkout staking info bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-core",
-	"version": "3.10.3",
+	"version": "3.10.3-beta.0",
 	"description": "Core library for Clubs",
 	"main": "dist/index.mjs",
 	"exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-core",
-	"version": "3.10.3-beta.0",
+	"version": "3.10.4",
 	"description": "Core library for Clubs",
 	"main": "dist/index.mjs",
 	"exports": {

--- a/src/ui/components/Checkout/Checkout.vue
+++ b/src/ui/components/Checkout/Checkout.vue
@@ -466,9 +466,9 @@ onMounted(async () => {
 			stakingAmount.value = !props.useDiscretePaymentFlow
 				? new BigNumber(devAmount ?? 0).dp(6).toNumber()
 				: undefined
-			
-			directAmount.value = !props.useDiscretePaymentFlow ?
-				new BigNumber(_amount).times(new BigNumber(feeDeposit)).toNumber()
+
+			directAmount.value = !props.useDiscretePaymentFlow
+				? new BigNumber(_amount).times(new BigNumber(feeDeposit)).toNumber()
 				: undefined
 
 			if (previewImageSrc.value || previewName.value) {
@@ -530,7 +530,12 @@ onUnmounted(() => {
 					{{ i18n('AutomaticStaking', [stakingAmount.toLocaleString()]) }}
 				</p>
 				<p v-if="directAmount" class="text-sm text-black/90">
-					{{ i18n('AutomaticEarned', [directAmount.toLocaleString(), verifiedPropsCurrency.toUpperCase()])}}
+					{{
+						i18n('AutomaticEarned', [
+							directAmount.toLocaleString(),
+							verifiedPropsCurrency.toUpperCase(),
+						])
+					}}
 				</p>
 			</span>
 			<aside

--- a/src/ui/components/Checkout/Checkout.vue
+++ b/src/ui/components/Checkout/Checkout.vue
@@ -75,6 +75,7 @@ const chain = ref<UndefinedOr<number>>(undefined)
 const previewImageSrc = ref<UndefinedOr<string>>(props.itemImageSrc)
 const previewName = ref<UndefinedOr<string>>(props.itemName)
 const stakingAmount = ref<UndefinedOr<number>>(undefined)
+const directAmount = ref<UndefinedOr<number>>(undefined)
 const isCheckingAccessControl = ref<boolean>(false)
 const accessControlError = ref<UndefinedOr<Error>>(undefined)
 const accessAllowed = ref<UndefinedOr<boolean>>(undefined)
@@ -454,7 +455,9 @@ onMounted(async () => {
 					: stakeWithAnyTokens({
 							provider,
 							propertyAddress: _destination,
-							tokenAmount: _amount.toString(),
+							tokenAmount: new BigNumber(_amount)
+								.times(new BigNumber(1).minus(feeDeposit))
+								.toString(),
 							currency: verifiedPropsCurrency.value,
 							chain: _chain,
 					  }).then((res) => formatUnits(res?.estimatedDev ?? 0)),
@@ -462,6 +465,10 @@ onMounted(async () => {
 
 			stakingAmount.value = !props.useDiscretePaymentFlow
 				? new BigNumber(devAmount ?? 0).dp(6).toNumber()
+				: undefined
+			
+			directAmount.value = !props.useDiscretePaymentFlow ?
+				new BigNumber(_amount).times(new BigNumber(feeDeposit)).toNumber()
 				: undefined
 
 			if (previewImageSrc.value || previewName.value) {
@@ -521,6 +528,9 @@ onUnmounted(() => {
 				</p>
 				<p v-if="stakingAmount" class="text-sm text-black/90">
 					{{ i18n('AutomaticStaking', [stakingAmount.toLocaleString()]) }}
+				</p>
+				<p v-if="directAmount" class="text-sm text-black/90">
+					{{ i18n('AutomaticEarned', [directAmount.toLocaleString(), verifiedPropsCurrency.toUpperCase()])}}
 				</p>
 			</span>
 			<aside

--- a/src/ui/components/Checkout/i18n/index.ts
+++ b/src/ui/components/Checkout/i18n/index.ts
@@ -53,8 +53,10 @@ export const Strings = {
 		en: ([amount]) => `${amount} DEV will be staked automatically.`,
 		ja: ([amount]) => `${amount} DEVは自動的にステーキングされます。`,
 	},
-	AutomaticEarned:{
-		en: ([amount, currency]) => `${amount} ${currency} will be directly earned by the owner!`,
-		ja: ([amount, currency]) => `${amount} ${currency} はオーナーに直接支払われます！`,
+	AutomaticEarned: {
+		en: ([amount, currency]) =>
+			`${amount} ${currency} will be directly earned by the owner!`,
+		ja: ([amount, currency]) =>
+			`${amount} ${currency} はオーナーに直接支払われます！`,
 	},
 } satisfies ClubsI18nParts

--- a/src/ui/components/Checkout/i18n/index.ts
+++ b/src/ui/components/Checkout/i18n/index.ts
@@ -51,6 +51,10 @@ export const Strings = {
 	},
 	AutomaticStaking: {
 		en: ([amount]) => `${amount} DEV will be staked automatically.`,
-		ja: ([amount]) => `DEVは自動的にステーキングされます。`,
+		ja: ([amount]) => `${amount} DEVは自動的にステーキングされます。`,
+	},
+	AutomaticEarned:{
+		en: ([amount, currency]) => `${amount} ${currency} will be directly earned by the owner!`,
+		ja: ([amount, currency]) => `${amount} ${currency} はオーナーに直接支払われます！`,
 	},
 } satisfies ClubsI18nParts


### PR DESCRIPTION
This fixes, the incorrect details as well as adds the direct earning amount

**Previous**
![image](https://github.com/dev-protocol/clubs-core/assets/57281769/3520ef81-bd19-4a6a-8bd0-4444b92990d9)

**Now**

<img width="912" alt="Screenshot 2024-04-12 at 1 42 27 PM" src="https://github.com/dev-protocol/clubs-core/assets/57281769/fcdfb31b-1662-4f0c-88d2-61ccca87cde7">
