### PR TITLE
Fixed a bug where MATIC was treated as WMATIC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-core",
-	"version": "3.12.8",
+	"version": "3.12.9",
 	"description": "Core library for Clubs",
 	"main": "dist/index.mjs",
 	"exports": {

--- a/src/ui/components/Checkout/Checkout.vue
+++ b/src/ui/components/Checkout/Checkout.vue
@@ -65,7 +65,6 @@ type Props = {
 }
 const props = defineProps<Props>()
 
-const approveNeeded = ref<UndefinedOr<boolean>>(undefined)
 const stakeSuccessful = ref<boolean>(false)
 const account = ref<UndefinedOr<string>>(undefined)
 const isApproving = ref<boolean>(false)
@@ -102,13 +101,22 @@ const usePolygonWETH: ComputedRef<boolean> = computed(() => {
 		(chain.value === 137 || chain.value === 80001)
 	)
 })
+const useEthreumWMATIC: ComputedRef<boolean> = computed(() => {
+	return (
+		verifiedPropsCurrency.value === CurrencyOption.MATIC &&
+		typeof chain.value === 'number' &&
+		chain.value === 1
+	)
+})
 const useERC20: ComputedRef<boolean> = computed(() => {
 	return (
 		(verifiedPropsCurrency.value !== CurrencyOption.ETH &&
 			verifiedPropsCurrency.value !== CurrencyOption.MATIC) ||
-		usePolygonWETH.value
+		usePolygonWETH.value ||
+		useEthreumWMATIC.value
 	)
 })
+const approveNeeded = ref<UndefinedOr<boolean>>(useERC20.value)
 const htmlDescription: ComputedRef<UndefinedOr<string>> = computed(() => {
 	return (
 		props.description && DOMPurify.sanitize(marked.parse(props.description))
@@ -430,7 +438,7 @@ onMounted(async () => {
 		whenDefinedAll(
 			[providerPool, _account, props.destination, props.amount, chain.value],
 			async ([_prov, _userAddress, _destination, _amount, _chain]) => {
-				useERC20 &&
+				useERC20.value &&
 					!props.useDiscretePaymentFlow &&
 					checkApproved(_prov, _userAddress, _destination, _amount, _chain)
 			}


### PR DESCRIPTION
Calling `checkApproved` on `onMounted` hook was referencing `useERC20` not `useERC20.value`, which caused the conditional expression to incorrectly return true. This caused the process to check for allowance as WMATIC even though MATIC on Polygon was selected.

https://github.com/dev-protocol/clubs-core/pull/1596/files#diff-ac21e31288cff7816199b948a3271b94f546d33346ff09a842f70fda61ef96b4R441