### PR TITLE
v3.19.1: New config field `.offerings` and new type `ClubsOffering`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-core",
-	"version": "3.18.0",
+	"version": "3.19.0",
 	"description": "Core library for Clubs",
 	"main": "dist/index.mjs",
 	"exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-core",
-	"version": "3.19.0",
+	"version": "3.19.1",
 	"description": "Core library for Clubs",
 	"main": "dist/index.mjs",
 	"exports": {

--- a/src/memberships.test.ts
+++ b/src/memberships.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import { membershipVerifierFactory, membershipToStruct } from './memberships'
+import {
+	membershipVerifierFactory,
+	membershipToStruct,
+	getOfferingsByPluginId,
+} from './memberships'
 import {
 	JsonRpcProvider,
 	MaxUint256,
@@ -684,3 +688,5 @@ describe('membershipToStruct', () => {
 		})
 	})
 })
+
+describe.skip('getOfferingsByPluginId')

--- a/src/memberships.test.ts
+++ b/src/memberships.test.ts
@@ -11,7 +11,7 @@ import {
 	formatUnits,
 	randomBytes,
 } from 'ethers'
-import { Membership } from './types'
+import { ClubsConfiguration, ClubsOffering, Membership } from './types'
 import { bytes32Hex } from './bytes32Hex'
 import axios from 'axios'
 import BigNumber from 'bignumber.js'
@@ -689,4 +689,118 @@ describe('membershipToStruct', () => {
 	})
 })
 
-describe.skip('findOfferings')
+describe('findOfferings', () => {
+	it('should return offerings', () => {
+		const offerings = [
+			{
+				managedBy: 'DEBUG',
+				payload: new Uint8Array([1, 2, 3]),
+				currency: 'DEV',
+				imageSrc: 'imageSrc',
+				name: 'name',
+				description: 'description',
+				fee: { beneficiary: '0x123', percentage: 0.1 },
+				id: 'id',
+			},
+			{
+				managedBy: 'DEBUG',
+				payload: new Uint8Array([10, 11, 12]),
+				currency: 'USDC',
+				imageSrc: 'imageSrc4',
+				name: 'name3',
+				description: 'description4',
+				fee: { beneficiary: '0x123', percentage: 0.1 },
+				id: 'id4',
+			},
+		] as readonly ClubsOffering[]
+		const config = {
+			offerings: [
+				...offerings,
+				{
+					managedBy: 'DEBUG2',
+					payload: new Uint8Array([3, 4, 5]),
+					currency: 'DEV',
+					imageSrc: 'imageSrc2',
+					name: 'name2',
+					description: 'description2',
+					fee: { beneficiary: '0x123', percentage: 0.1 },
+					id: 'id2',
+				},
+				{
+					managedBy: 'DEBUG',
+					payload: new Uint8Array([7, 8, 9]),
+					currency: 'USDC',
+					imageSrc: 'imageSrc3',
+					name: 'name3',
+					description: 'description3',
+					fee: { beneficiary: '0x456', percentage: 0.1 },
+					id: 'id3',
+				},
+			] as readonly ClubsOffering[],
+		} as unknown as ClubsConfiguration
+		const res = findOfferings(config, {
+			managedBy: 'DEBUG',
+			fee: { beneficiary: '0x123' },
+		})
+
+		expect(res).toEqual(offerings)
+	})
+
+	it('should always handling payload as a string', () => {
+		const offerings = [
+			{
+				managedBy: 'DEBUG',
+				payload: new Uint8Array([1, 2, 3]),
+				currency: 'DEV',
+				imageSrc: 'imageSrc',
+				name: 'name',
+				description: 'description',
+				fee: { beneficiary: '0x123', percentage: 0.1 },
+				id: 'id',
+			},
+		] as readonly ClubsOffering[]
+		const config = {
+			offerings: [
+				...offerings,
+				{
+					managedBy: 'DEBUG2',
+					payload: new Uint8Array([3, 4, 5]),
+					currency: 'DEV',
+					imageSrc: 'imageSrc2',
+					name: 'name2',
+					description: 'description2',
+					fee: { beneficiary: '0x123', percentage: 0.1 },
+					id: 'id2',
+				},
+				{
+					managedBy: 'DEBUG',
+					payload: new Uint8Array([7, 8, 9]),
+					currency: 'USDC',
+					imageSrc: 'imageSrc3',
+					name: 'name3',
+					description: 'description3',
+					fee: { beneficiary: '0x456', percentage: 0.1 },
+					id: 'id3',
+				},
+				{
+					managedBy: 'DEBUG',
+					payload: new Uint8Array([10, 11, 12]),
+					currency: 'USDC',
+					imageSrc: 'imageSrc4',
+					name: 'name3',
+					description: 'description4',
+					fee: { beneficiary: '0x123', percentage: 0.1 },
+					id: 'id4',
+				},
+			] as readonly ClubsOffering[],
+		} as unknown as ClubsConfiguration
+		const res = findOfferings(config, {
+			managedBy: 'DEBUG',
+			payload: bytes32Hex(new Uint8Array([1, 2, 3])),
+		})
+
+		expect(res).toEqual(offerings)
+	})
+
+	it.skip('... test more ...')
+})

--- a/src/memberships.test.ts
+++ b/src/memberships.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
 	membershipVerifierFactory,
 	membershipToStruct,
-	getOfferingsByPluginId,
+	getPluginManagedOfferingsById,
 } from './memberships'
 import {
 	JsonRpcProvider,
@@ -689,4 +689,4 @@ describe('membershipToStruct', () => {
 	})
 })
 
-describe.skip('getOfferingsByPluginId')
+describe.skip('getPluginManagedOfferingsById')

--- a/src/memberships.test.ts
+++ b/src/memberships.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
 	membershipVerifierFactory,
 	membershipToStruct,
-	getPluginManagedOfferingsById,
+	findOfferings,
 } from './memberships'
 import {
 	JsonRpcProvider,
@@ -689,4 +689,4 @@ describe('membershipToStruct', () => {
 	})
 })
 
-describe.skip('getPluginManagedOfferingsById')
+describe.skip('findOfferings')

--- a/src/memberships.ts
+++ b/src/memberships.ts
@@ -237,12 +237,12 @@ export const membershipToStruct = (
 }
 
 /**
- * Get offerings that match managedBy and the specified plugin ID.
+ * Find offerings that match managedBy and the specified plugin ID.
  * @param config ClubsConfigration
  * @param pluginId plugin ID
  * @returns an array of filtered offerings
  */
-export const getPluginManagedOfferingsById = (
+export const findOfferings = (
 	config: ClubsConfiguration,
 	pluginId: string
 ): readonly ClubsOffering[] => {

--- a/src/memberships.ts
+++ b/src/memberships.ts
@@ -242,7 +242,7 @@ export const membershipToStruct = (
  * @param pluginId plugin ID
  * @returns an array of filtered offerings
  */
-export const getOfferingsByPluginId = (
+export const getPluginManagedOfferingsById = (
 	config: ClubsConfiguration,
 	pluginId: string
 ): readonly ClubsOffering[] => {

--- a/src/memberships.ts
+++ b/src/memberships.ts
@@ -17,7 +17,7 @@ import {
 	whenNotErrorAll,
 } from '@devprotocol/util-ts'
 import { always, type KeyValuePair, xprod } from 'ramda'
-import type { Membership } from './types'
+import type { ClubsConfiguration, ClubsOffering, Membership } from './types'
 import axios from 'axios'
 import { bytes32Hex } from './bytes32Hex'
 import pQueue from 'p-queue'
@@ -234,4 +234,20 @@ export const membershipToStruct = (
 		gateway: hasNoPrice ? ZeroAddress : mem.fee?.beneficiary ?? ZeroAddress,
 		token: token ?? ZeroAddress,
 	}
+}
+
+/**
+ * Get offerings that match managedBy and the specified plugin ID.
+ * @param config ClubsConfigration
+ * @param pluginId plugin ID
+ * @returns an array of filtered offerings
+ */
+export const getOfferingsByPluginId = (
+	config: ClubsConfiguration,
+	pluginId: string
+): readonly ClubsOffering[] => {
+	const filtered = (config.offerings ?? []).filter(
+		({ managedBy }) => managedBy === pluginId
+	)
+	return filtered
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,9 @@ export type ClubsPluginDetails<
 		readonly pluginIndex: number
 	}>
 
+export type ClubsOffering = Membership &
+	Readonly<{ readonly managedBy: string }>
+
 export type ClubsConfiguration = Readonly<{
 	readonly name: string
 	readonly adminPageVisibility?: 'public' | 'private'
@@ -53,6 +56,7 @@ export type ClubsConfiguration = Readonly<{
 	readonly adminRolePoints: number
 	readonly chainId: number
 	readonly rpcUrl: string
+	readonly offerings?: readonly ClubsOffering[]
 	readonly options?: ClubsPluginOptions
 	readonly plugins: readonly ClubsPlugin[]
 }>


### PR DESCRIPTION
Added a new built-in configuration field `offerings`, a new type `ClubsOffering`, and a helper function to find offerings from a ClubsConfiguration.

### Find offerings
```ts
import {findOfferings} from '@devprotocol/clubs-core'

findOfferings({ /*ClubsConfigration*/ }, {managedBy: 'example:clubs:plugin:xyz'})
// => [ {payload: '...', price: 10, currency: 'USDC'}, { /*...*/ } ]
```

### Set offerings in a plugin
```ts
import {setConfig} from '@devprotocol/clubs-core'

// ::PLAN:: we can provide a shorthand like `setOfferings` instead of `setConfig`, in the future.
const newConfig = {
  ...initialConfig,
  offerings: [
    ...initialConfig.offerings.filter(({managedBy}) => managedBy !== 'example:clubs:plugin:xyz'),
    ...memberships.map(mem => ({...mem, managedBy: 'example:clubs:plugin:xyz'}))
  ]
}

setConfig(newConfig)
```
