### PR TITLE
Update Japanese translation in Checkout i18n

### DIFF
--- a/src/ui/components/Checkout/i18n/index.ts
+++ b/src/ui/components/Checkout/i18n/index.ts
@@ -47,7 +47,7 @@ export const Strings = {
 	},
 	PayWith: {
 		en: ([currency]) => `Pay with ${currency}`,
-		ja: () => `次の貨幣で支払う：`,
+		ja: ([currency]) => `次の貨幣で支払う：${currency}`,
 	},
 	Minted: {
 		en: 'Minted',


### PR DESCRIPTION
Corrected the Japanese translation for the 'PayWith' function to include the currency parameter, ensuring consistency with the English version. This change improves the clarity and accuracy of language localization in the checkout component.