### PR TITLE
fix: prevent decimal approximation in basisPoints calc by node/js

### DIFF
--- a/src/ui/components/Checkout/Checkout.vue
+++ b/src/ui/components/Checkout/Checkout.vue
@@ -313,7 +313,7 @@ const submitStake = async function () {
 								gatewayAddress: props.feeBeneficiary ?? undefined,
 								gatewayBasisPoints:
 									typeof props.feePercentage === 'number'
-										? props.feePercentage * 10_000
+										? parseInt((props.feePercentage * 10_000).toString())
 										: undefined,
 								payload: props.payload,
 							}).catch((err: Error) => {
@@ -346,7 +346,7 @@ const submitStake = async function () {
 								gatewayAddress: props.feeBeneficiary ?? undefined,
 								gatewayBasisPoints:
 									typeof props.feePercentage === 'number'
-										? props.feePercentage * 10_000
+										? parseInt((props.feePercentage * 10_000).toString())
 										: undefined,
 								payload: props.payload,
 								from: _account,


### PR DESCRIPTION
I encountered a situation where my offering.fee.percentage = 0.17 but the basisPoints generated was around 1700.0000002. I guess this happens due to approximation issue of node.js hence this PR.

<img width="1345" alt="Screenshot_2024-12-18_at_4 39 46_PM" src="https://github.com/user-attachments/assets/0ad30488-68f4-4300-b0f9-082eab4f895e" />
