### PR TITLE
Slotted `preview` image

### DIFF
--- a/example/Checkout.astro
+++ b/example/Checkout.astro
@@ -25,6 +25,21 @@ const payload = toUtf8Bytes('tier-1')
 		uiMode="embed"
 		{...props}
 	>
+		<span
+			slot="checkout:preview"
+			class="h-auto min-h-24 w-24 rounded-lg border border-black/20 bg-black/10 p-1"
+		>
+			<img
+				v-if="previewImageSrc"
+				class="h-auto w-full rounded-lg object-cover object-center"
+				src="https://images.unsplash.com/photo-1652489997190-f492cfbbdf7e?q=80&w=1200&h=1200&fit=crop"
+			/>
+		</span>
+		<img
+			slot="checkout:result:preview"
+			class="z-10 max-h-60 min-h-full max-w-60 rounded-md object-contain @xl/clb_result_modal:max-h-none @xl/clb_result_modal:max-w-xl"
+			src="https://images.unsplash.com/photo-1688168293343-e1c824a4ace5?q=80&w=1200&h=1200&fit=crop"
+		/>
 		<div class="opacity-50" slot="checkout:after:description">
 			We strictly prohibit any unauthorized reproduction, reprinting, reuse, or
 			modification of any part or all of the content (images, text, etc.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-core",
-	"version": "3.26.7-beta.2",
+	"version": "3.26.7-beta.3",
 	"description": "Core library for Clubs",
 	"main": "dist/index.mjs",
 	"exports": {

--- a/src/ui/components/Checkout/Checkout.astro
+++ b/src/ui/components/Checkout/Checkout.astro
@@ -58,6 +58,12 @@ const SlotsCheckoutMainTransactionForm = clubs.slots.filter(
 const SlotsCheckoutAfterPrice = clubs.slots.filter(
 	(slot) => slot.slot === 'checkout:after:price'
 )
+const SlotsCheckoutPreview = clubs.slots.filter(
+	(slot) => slot.slot === 'checkout:preview'
+)
+const SlotsCheckoutResultPreview = clubs.slots.filter(
+	(slot) => slot.slot === 'checkout:result:preview'
+)
 const SlotsCheckoutResultBeforePreview = clubs.slots.filter(
 	(slot) => slot.slot === 'checkout:result:before:preview'
 )
@@ -97,6 +103,8 @@ const SlotsCheckoutAfterSignInForm = clubs.slots.filter(
 	<slot name="checkout:after:transaction-form" slot="after:transaction-form" />
 	<slot name="checkout:main:transaction-form" slot="main:transaction-form" />
 	<slot name="checkout:after:price" slot="after:price" />
+	<slot name="checkout:preview" slot="preview" />
+	<slot name="checkout:result:preview" slot="result:preview" />
 	<slot name="checkout:result:before:preview" slot="result:before:preview" />
 	<slot name="checkout:after:description" slot="after:description" />
 	<slot name="checkout:after:sign-in-form" slot="after:sign-in-form" />
@@ -134,6 +142,24 @@ const SlotsCheckoutAfterSignInForm = clubs.slots.filter(
 				{...Slot.props}
 				checkoutOptions={checkoutOptions}
 				slot="after:price"
+			/>
+		))
+	}
+	{
+		SlotsCheckoutPreview.map((Slot) => (
+			<Slot.component
+				{...Slot.props}
+				checkoutOptions={checkoutOptions}
+				slot="preview"
+			/>
+		))
+	}
+	{
+		SlotsCheckoutResultPreview.map((Slot) => (
+			<Slot.component
+				{...Slot.props}
+				checkoutOptions={checkoutOptions}
+				slot="result:preview"
 			/>
 		))
 	}

--- a/src/ui/components/Checkout/Checkout.vue
+++ b/src/ui/components/Checkout/Checkout.vue
@@ -438,6 +438,10 @@ const signIn = () =>
 	connection.value?.().signal.next(ClubsConnectionSignal.SignInRequest)
 
 onMounted(async () => {
+	// setTimeout(() => {
+	// 	stakeSuccessful.value = true
+	// }, 2000)
+
 	const { connection: _connection } = await import('../../../connection')
 	connection.value = _connection
 
@@ -587,29 +591,36 @@ onUnmounted(() => {
 				<div
 					class="grid grid-cols-[auto_auto_1fr] items-center justify-between gap-4"
 				>
-					<span
-						v-if="!previewImageSrc && previewVideoSrc"
-						class="w-36 rounded-lg border border-black/20 bg-black/10 p-1"
-					>
-						<VideoFetch
-							:url="previewVideoSrc"
-							:videoClass="`w-full rounded aspect-square`"
-						/>
-					</span>
+					<span class="contents">
+						<!-- This uses CSS instead of Vue's slot fallback content because Astro always inserts an empty element into the slot. -->
+						<span class="peer contents">
+							<slot name="preview" />
+						</span>
+						<span class="contents peer-has-[:not(:empty)]:hidden">
+							<span
+								v-if="!previewImageSrc && previewVideoSrc"
+								class="w-36 rounded-lg border border-black/20 bg-black/10 p-1"
+							>
+								<VideoFetch
+									:url="previewVideoSrc"
+									:videoClass="`w-full rounded aspect-square`"
+								/>
+							</span>
 
-					<span
-						v-if="!previewVideoSrc"
-						class="h-auto min-h-24 w-24 rounded-lg border border-black/20 bg-black/10 p-1"
-					>
-						<img
-							v-if="previewImageSrc"
-							ref="imageRef"
-							class="h-auto w-full rounded-lg object-cover object-center"
-						/>
-						<Skeleton
-							v-if="previewImageSrc === undefined"
-							class="mx-auto aspect-square h-full w-full"
-						/>
+							<span
+								v-if="!previewVideoSrc"
+								class="h-auto min-h-24 w-24 rounded-lg border border-black/20 bg-black/10 p-1"
+							>
+								<img
+									v-if="previewImageSrc"
+									ref="imageRef"
+									class="h-auto w-full rounded-lg object-cover object-center"
+								/>
+								<Skeleton
+									v-if="previewImageSrc === undefined"
+									class="mx-auto aspect-square h-full w-full"
+								/> </span
+						></span>
 					</span>
 					<h3 class="text-balance break-all font-bold">{{ previewName }}</h3>
 					<span class="justify-self-end">
@@ -905,6 +916,9 @@ onUnmounted(() => {
 		:video-src="previewVideoSrc"
 		:base="props.base"
 	>
+		<template #preview>
+			<slot name="result:preview" />
+		</template>
 		<template #before:preview>
 			<slot name="result:before:preview" />
 		</template>

--- a/src/ui/components/Checkout/ModalCheckout.vue
+++ b/src/ui/components/Checkout/ModalCheckout.vue
@@ -184,18 +184,26 @@ onMounted(async () => {
 				>
 			</h3>
 			<!-- image -->
-			<img
-				v-if="imageSrc"
-				ref="imageRef"
-				class="z-10 max-h-60 min-h-full max-w-60 rounded-md object-contain @xl/clb_result_modal:max-h-none @xl/clb_result_modal:max-w-xl"
-			/>
-			<!-- video -->
-			<VideoFetch
-				v-if="!imageSrc && videoSrc"
-				class="aspect-[1/1] max-w-60 rounded-md"
-				video-class="rounded-md [&>video]:rounded-md"
-				:url="videoSrc"
-			/>
+			<span class="contents">
+				<!-- This uses CSS instead of Vue's slot fallback content because Astro always inserts an empty element into the slot. -->
+				<span class="peer contents">
+					<slot name="preview" />
+				</span>
+				<span class="contents peer-has-[:not(:empty)]:hidden">
+					<img
+						v-if="imageSrc"
+						ref="imageRef"
+						class="z-10 max-h-60 min-h-full max-w-60 rounded-md object-contain @xl/clb_result_modal:max-h-none @xl/clb_result_modal:max-w-xl"
+					/>
+					<!-- video -->
+					<VideoFetch
+						v-if="!imageSrc && videoSrc"
+						class="aspect-[1/1] max-w-60 rounded-md"
+						video-class="rounded-md [&>video]:rounded-md"
+						:url="videoSrc"
+					/>
+				</span>
+			</span>
 			<span class="text-base italic text-white">
 				{{ i18n('PurchaseGreeting') }}
 			</span>

--- a/src/ui/components/Checkout/Result.vue
+++ b/src/ui/components/Checkout/Result.vue
@@ -55,6 +55,9 @@ onMounted(async () => {
 			base,
 		}"
 	>
+		<template #preview>
+			<slot name="preview" />
+		</template>
 		<template #after:description>
 			<slot name="before:preview" />
 		</template>

--- a/src/ui/components/Modal.vue
+++ b/src/ui/components/Modal.vue
@@ -56,6 +56,9 @@ html:has(dialog[open]) {
 				:is="modalContent"
 				v-bind="attrs"
 			>
+				<template #preview>
+					<slot name="preview" />
+				</template>
 				<template #after:description>
 					<slot name="after:description" />
 				</template>


### PR DESCRIPTION
`<Checkout/>` is now supporting `preview` and `result:preview` slots.

When an application passes the `preview' slot, `<checkout>' will render the slot as the preview image/video section, and the `result:preview' slot works similarly for the result modal.